### PR TITLE
Actualizaciones en las tarifa Pulpo Pepe, añadido Pupo Pepe + Datos y corregida Tarifa Cotorra

### DIFF
--- a/src/com/conzebit/myplan/core/plan/PlanService.java
+++ b/src/com/conzebit/myplan/core/plan/PlanService.java
@@ -105,9 +105,11 @@ import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneLoboCordero;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneMovilonia9;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneMoviloniaVIP;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhonePulpo;
+import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhonePulpoDatos;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneRatoncitoElefante;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneShurperro;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneSinAnimal;
+import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneSinAnimalDatos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo0y8centimos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo3centimos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo5centimos;
@@ -248,9 +250,11 @@ public class PlanService {
 		this.plans.add(new ESPepePhoneMovilonia9());
 		this.plans.add(new ESPepePhoneMoviloniaVIP());
 		this.plans.add(new ESPepePhonePulpo());
+		this.plans.add(new ESPepePhonePulpoDatos());
 		this.plans.add(new ESPepePhoneRatoncitoElefante());
 		this.plans.add(new ESPepePhoneShurperro());
 		this.plans.add(new ESPepePhoneSinAnimal());
+		this.plans.add(new ESPepePhoneSinAnimalDatos());
 		this.plans.add(new ESPepePhoneLoboCordero());
 
 		this.plans.add(new ESSimyo0y8centimos());

--- a/src/com/conzebit/myplan/core/plan/PlanService.java
+++ b/src/com/conzebit/myplan/core/plan/PlanService.java
@@ -110,6 +110,7 @@ import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneRatoncitoEle
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneShurperro;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneSinAnimal;
 import com.conzebit.myplan.ext.es.pepephone.particulares.ESPepePhoneSinAnimalDatos;
+import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo0y6centimos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo0y8centimos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo3centimos;
 import com.conzebit.myplan.ext.es.simyo.particulares.ESSimyo5centimos;
@@ -260,6 +261,7 @@ public class PlanService {
 		this.plans.add(new ESSimyo0y8centimos());
 		this.plans.add(new ESSimyo3centimos());
 		this.plans.add(new ESSimyo5centimos());
+		this.plans.add(new ESSimyo0y6centimos());
 
 		this.plans.add(new ESVodafoneAire90x124h());
 		this.plans.add(new ESVodafoneAire90x1ATodos());

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneCotorra.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneCotorra.java
@@ -34,6 +34,7 @@ public class ESPepePhoneCotorra extends ESPepePhone {
     
 	private double initialPrice = 0.15;
 	private double smsPrice = 0.09;
+	private double monthFee = 6.9;
     
 	public String getPlanName() {
 		return "Tarifa Cotorra Pepe";
@@ -41,6 +42,10 @@ public class ESPepePhoneCotorra extends ESPepePhone {
 	
 	public String getPlanURL() {
 		return "http://www.pepephone.com/promo/elandroidelibre-cotorra/";
+	}
+	
+	public Double getMonthFee() {
+		return monthFee;
 	}
 	
 	public ProcessResult processCall(Call call, Map<String, Object> accumulatedData) {

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpo.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpo.java
@@ -54,7 +54,7 @@ public class ESPepePhonePulpo extends ESPepePhone {
 			ret.type = Type.ZERO;
 		} else {
 			double pricePerSecond = (int) (call.getDuration() / 60);
-			pricePerSecond = ((pricePerSecond >= 4) ? 0.049 : pricePerSecond / 100) / 60;
+			pricePerSecond = ((pricePerSecond >= 4) ? 0.046 : pricePerSecond / 100) / 60;
 			ret.price = initialPrice + (call.getDuration() * pricePerSecond);
 			ret.type = Type.INSIDE_PLAN;
 		}

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpoDatos.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpoDatos.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of myPlan.
+ *
+ * Plan is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Plan is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with myPlan.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.conzebit.myplan.ext.es.pepephone.particulares;
+
+import java.util.Map;
+
+import com.conzebit.myplan.core.call.Call;
+import com.conzebit.myplan.core.msisdn.MsisdnType;
+import com.conzebit.myplan.core.plan.PlanChargeable.Type;
+import com.conzebit.myplan.core.sms.Sms;
+import com.conzebit.myplan.ext.es.pepephone.ESPepePhone;
+
+
+/**
+ * PepePhone Pulpo + Datos
+ * 
+ * @author sanz
+ */
+public class ESPepePhonePulpoDatos extends ESPepePhone {
+    
+	private double initialPrice = 0.15;
+	private double smsPrice = 0.09;
+	private double monthFee = 6.9;
+    
+	public String getPlanName() {
+		return "Tarifa Pulpo Pepe + Datos";
+	}
+	
+	public String getPlanURL() {
+		return "http://www.pepephone.com/promo/adslzone-pulpopepe/index.html";
+	}
+	
+	public Double getMonthFee() {
+		return monthFee;
+	}
+	
+	public ProcessResult processCall(Call call, Map<String, Object> accumulatedData) {
+		if (call.getType() != Call.CALL_TYPE_SENT) {
+			return null;
+		}
+
+		ProcessResult ret = new ProcessResult();
+		if (call.getContact().getMsisdnType() == MsisdnType.ES_SPECIAL_ZER0) {
+			ret.price = 0.0;
+			ret.type = Type.ZERO;
+		} else {
+			double pricePerSecond = (int) (call.getDuration() / 60);
+			pricePerSecond = ((pricePerSecond >= 4) ? 0.040 : pricePerSecond / 100) / 60;
+			ret.price = initialPrice + (call.getDuration() * pricePerSecond);
+			ret.type = Type.INSIDE_PLAN;
+		}
+		return ret;
+	}
+
+	public ProcessResult processSms(Sms sms, Map<String, Object> accumulatedData) {
+		if (sms.getType() != Sms.SMS_TYPE_SENT) {
+			return null;
+		}
+		ProcessResult ret = new ProcessResult();
+		ret.price = smsPrice;
+		ret.type = Type.INSIDE_PLAN;
+		return ret;
+	}
+}

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpoDatos.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhonePulpoDatos.java
@@ -37,7 +37,7 @@ public class ESPepePhonePulpoDatos extends ESPepePhone {
 	private double monthFee = 6.9;
     
 	public String getPlanName() {
-		return "Tarifa Pulpo Pepe + Datos";
+		return "Pulpo Pepe + Datos";
 	}
 	
 	public String getPlanURL() {

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimal.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimal.java
@@ -26,7 +26,7 @@ import com.conzebit.myplan.ext.es.pepephone.ESPepePhone;
 
 
 /**
- * PepePhone Sin Animal
+ * PepePhone Sin Animal + Datos
  * 
  * @author sanz
  */

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimalDatos.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimalDatos.java
@@ -38,7 +38,7 @@ public class ESPepePhoneSinAnimalDatos extends ESPepePhone {
 	private double monthFee = 6.9;
     
 	public String getPlanName() {
-		return "Tarifa Sin animal + Datos";
+		return "Sin animal + Datos";
 	}
 	
 	public String getPlanURL() {

--- a/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimalDatos.java
+++ b/src/com/conzebit/myplan/ext/es/pepephone/particulares/ESPepePhoneSinAnimalDatos.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of myPlan.
+ *
+ * Plan is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Plan is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with myPlan.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.conzebit.myplan.ext.es.pepephone.particulares;
+
+import java.util.Map;
+
+import com.conzebit.myplan.core.call.Call;
+import com.conzebit.myplan.core.msisdn.MsisdnType;
+import com.conzebit.myplan.core.plan.PlanChargeable.Type;
+import com.conzebit.myplan.core.sms.Sms;
+import com.conzebit.myplan.ext.es.pepephone.ESPepePhone;
+
+
+/**
+ * PepePhone Sin Animal
+ * 
+ * @author sanz
+ */
+public class ESPepePhoneSinAnimalDatos extends ESPepePhone {
+    
+	private double initialPrice = 0.15;
+	private double pricePerSecond = 0.06 / 60;
+	private double smsPrice = 0.09;
+	private double monthFee = 6.9;
+    
+	public String getPlanName() {
+		return "Tarifa Sin animal + Datos";
+	}
+	
+	public String getPlanURL() {
+		return "http://pepephone.com/promo/mimovilwindows/";
+	}
+	
+	public Double getMonthFee() {
+		return monthFee;
+	}
+	
+	public ProcessResult processCall(Call call, Map<String, Object> accumulatedData) {
+		if (call.getType() != Call.CALL_TYPE_SENT) {
+			return null;
+		}
+		
+		ProcessResult ret = new ProcessResult();
+		if (call.getContact().getMsisdnType() == MsisdnType.ES_SPECIAL_ZER0) {
+			ret.price = 0.0;
+			ret.type = Type.ZERO;
+		} else {
+			ret.price = (call.getDuration() < 60 ? 0.0 : initialPrice) + (call.getDuration() * pricePerSecond);
+			ret.type = Type.INSIDE_PLAN;
+		}
+		return ret;
+	}
+
+	public ProcessResult processSms(Sms sms, Map<String, Object> accumulatedData) {
+		if (sms.getType() != Sms.SMS_TYPE_SENT) {
+			return null;
+		}
+		ProcessResult ret = new ProcessResult();
+		ret.price = smsPrice;
+		ret.type = Type.INSIDE_PLAN;
+		return ret;
+	}
+}

--- a/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo0y6centimos.java
+++ b/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo0y6centimos.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of myPlan.
+ *
+ * Plan is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * Plan is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with myPlan.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.conzebit.myplan.ext.es.simyo.particulares;
+
+import java.util.ArrayList;
+
+import com.conzebit.myplan.core.Chargeable;
+import com.conzebit.myplan.core.call.Call;
+
+import com.conzebit.myplan.core.message.ChargeableMessage;
+import com.conzebit.myplan.core.msisdn.MsisdnType;
+import com.conzebit.myplan.core.plan.PlanChargeable;
+import com.conzebit.myplan.core.plan.PlanSummary;
+import com.conzebit.myplan.core.sms.Sms;
+import com.conzebit.myplan.ext.es.simyo.ESSimyo;
+
+
+/**
+ * Simyo 0 y 6 cents.
+ * @author aalmenar
+ */
+public class ESSimyo0y6centimos extends ESSimyo {
+    
+	private double minimumMonthFee = 3.99;
+	private double initialPrice = 0.15;
+	private double pricePerSecond = 0.06 / 60;
+	private int maxFreeSeconds = 10 * 60;
+	private double smsPrice = 0.09;
+    
+	public String getPlanName() {
+		return "0 y 6 céntimos";
+	}
+	
+	public String getPlanURL() {
+		return "http://www.simyo.es/tarifas.html";
+	}
+	
+	public PlanSummary process(ArrayList<Chargeable> data) {
+		PlanSummary ret = new PlanSummary(this);
+		double globalPrice = 0;
+		for (Chargeable chargeable : data) {
+			if (chargeable.getChargeableType() == Chargeable.CHARGEABLE_TYPE_CALL) {
+				Call call = (Call) chargeable;
+
+				if (call.getType() != Call.CALL_TYPE_SENT) {
+					continue;
+				}
+	
+				double callPrice = 0;
+	
+				if (call.getContact().getMsisdnType() == MsisdnType.ES_SPECIAL_ZER0) {
+					callPrice = 0;
+				} else {
+					if (call.getContact().getMsisdnType() == MsisdnType.ES_SIMYO) {
+						if (call.getDuration() <= maxFreeSeconds) {
+							callPrice = initialPrice;
+						} else {
+							callPrice = initialPrice + ((call.getDuration() - maxFreeSeconds) * pricePerSecond);
+						}
+					} else  {
+						callPrice = initialPrice + (call.getDuration() * pricePerSecond);
+					}
+				}
+				globalPrice += callPrice;
+				ret.addPlanCall(new PlanChargeable(call, callPrice, this.getCurrency()));
+			} else if (chargeable.getChargeableType() == Chargeable.CHARGEABLE_TYPE_SMS) {
+				Sms sms = (Sms) chargeable;
+				if (sms.getType() == Sms.SMS_TYPE_RECEIVED) {
+					continue;
+				}
+				globalPrice += smsPrice;
+				ret.addPlanCall(new PlanChargeable(chargeable, smsPrice, this.getCurrency()));
+			}
+		}
+		if (globalPrice < minimumMonthFee) {
+			ret.addPlanCall(new PlanChargeable(new ChargeableMessage(ChargeableMessage.MESSAGE_MINIMUM_MONTH_FEE), minimumMonthFee - globalPrice, this.getCurrency()));
+		}
+		return ret;
+	}
+}

--- a/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo3centimos.java
+++ b/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo3centimos.java
@@ -41,7 +41,7 @@ public class ESSimyo3centimos extends ESSimyo {
 	private double smsPrice = 0.09;
     
 	public String getPlanName() {
-		return "3 céntimos (inc 500MB datos)";
+		return "3 céntimos (inc 650MB datos)";
 	}
 	
 	public String getPlanURL() {

--- a/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo5centimos.java
+++ b/src/com/conzebit/myplan/ext/es/simyo/particulares/ESSimyo5centimos.java
@@ -41,7 +41,7 @@ public class ESSimyo5centimos extends ESSimyo {
 	private double smsPrice = 0.09;
     
 	public String getPlanName() {
-		return "5 céntimos";
+		return "5 céntimos (inc 555MB datos)";
 	}
 	
 	public String getPlanURL() {


### PR DESCRIPTION
Actualice la tarifa pulpo pepe que está en 4,6 cents.

Añadi Tarifa Pulpo Pepe + Datos que el minutos es max. a 4,0 cents.

Corregida la Tarifa Cotorra que dee contratarse con el bono de datos de 651MB a 6,9 Eur/mes.
